### PR TITLE
Ignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
See title

Don't know why nextjs doesn't ignore this by default
